### PR TITLE
Add commands and mappings to toggle functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ git clone https://github.com/srstevenson/vim-topiary \
     ${XDG_DATA_HOME:-$HOME/.local/share}/nvim/site/pack/plugins/start/vim-topiary
 ```
 
+## Commands
+
+vim-topiary provides the following commands:
+
+* `:TopiaryEnable`: Enable whitespace trimming globally.
+* `:TopiaryDisable`: Disable whitespace trimming globally.
+* `:TopiaryToggle`: Toggle whitespace trimming globally.
+* `:TopiaryEnableBuffer`: Enable whitespace trimming for the current buffer.
+* `:TopiaryDisableBuffer`: Disable whitespace trimming for the current buffer.
+* `:TopiaryToggleBuffer`: Toggle whitespace trimming for the current buffer.
+
+## Key mappings
+
+vim-topiary defines the following [`<Plug>`][plug-mappings] mappings:
+
+* `<Plug>TopiaryEnable`: Execute `:TopiaryEnable`.
+* `<Plug>TopiaryDisable`: Execute `:TopiaryDisable`.
+* `<Plug>TopiaryToggle`: Execute `:TopiaryToggle`.
+* `<Plug>TopiaryEnableBuffer`: Execute `:TopiaryEnableBuffer`.
+* `<Plug>TopiaryDisableBuffer`: Execute `:TopiaryDisableBuffer`.
+* `<Plug>TopiaryToggleBuffer`: Execute `:TopiaryToggleBuffer`.
+
+These are not mapped to key sequences, to allow you to choose those that best
+fit your workflow and don't conflict with other plugins you use.
+
 ## Configuration
 
 To disable vim-topiary for specific filetypes, set `g:topiary_ft_disabled` in
@@ -72,6 +97,7 @@ vim-topiary is distributed under the terms of the [ISC licence].
 [minpac]: https://github.com/k-takata/minpac
 [packages]: https://neovim.io/doc/user/repeat.html#packages
 [packpath]: https://neovim.io/doc/user/options.html#'packpath'
+[plug-mappings]: https://neovim.io/doc/user/map.html#%3CPlug%3E
 [Scott Stevenson]: https://scott.stevenson.io
 [vim-plug]: https://github.com/junegunn/vim-plug
 [vim-topiary]: https://github.com/srstevenson/vim-topiary

--- a/autoload/topiary.vim
+++ b/autoload/topiary.vim
@@ -73,17 +73,71 @@ function! topiary#CheckIsList(variable, name) abort
     endif
 endfunction
 
+function! topiary#CheckIsNumber(variable, name) abort
+    " Print an error message if variable is not of type Number.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    " name : String
+    "     Name of the variable.
+    if type(a:variable) != type(0)
+        echomsg 'Error:' a:name 'must be a number'
+    endif
+endfunction
+
 function! topiary#TrimWhitespace() abort
-    " Trim whitespace from the current buffer, is buffer does not have a
-    " disabled filetype.
-    if s:InList(&filetype, g:topiary_ft_disabled)
-        return
+    " Trim whitespace from the current buffer, if vim-topiary is enabled in
+    " the buffer, or globally if there is no buffer local configuration, and
+    " if the buffer is not of a blacklisted filetype.
+    if exists('b:topiary_enabled')
+        let l:enabled = b:topiary_enabled
+    else
+        let l:enabled = g:topiary_enabled
     endif
 
-    let l:view = winsaveview()
-    call s:TrimEOLWhitespace()
-    call s:TrimLeadingBlankLines()
-    call s:TrimTrailingBlankLines()
-    call s:CollapseMultipleBlankLines()
-    call winrestview(l:view)
+    if l:enabled
+        if s:InList(&filetype, g:topiary_ft_disabled)
+            return
+        endif
+
+        let l:view = winsaveview()
+        call s:TrimEOLWhitespace()
+        call s:TrimLeadingBlankLines()
+        call s:TrimTrailingBlankLines()
+        call s:CollapseMultipleBlankLines()
+        call winrestview(l:view)
+    endif
+endfunction
+
+function! topiary#ToggleBuffer() abort
+    " Toggle whitespace trimming for the current buffer.
+    let l:enabled = !get(b:, 'topiary_enabled', g:topiary_enabled)
+    call setbufvar(bufnr(''), 'topiary_enabled', l:enabled)
+endfunction
+
+function! topiary#EnableBuffer() abort
+    " Enable whitespace trimming for the current buffer.
+    call setbufvar(bufnr(''), 'topiary_enabled', 1)
+endfunction
+
+function! topiary#DisableBuffer() abort
+    " Disable whitespace trimming for the current buffer.
+    call setbufvar(bufnr(''), 'topiary_enabled', 0)
+endfunction
+
+function! topiary#Toggle() abort
+    " Toggle whitespace trimming globally.
+    let g:topiary_enabled = !g:topiary_enabled
+endfunction
+
+function! topiary#Enable() abort
+    " Enable whitespace trimming globally.
+    let g:topiary_enabled = 1
+endfunction
+
+function! topiary#Disable() abort
+    " Disable whitespace trimming globally.
+    let g:topiary_enabled = 0
 endfunction

--- a/doc/topiary.txt
+++ b/doc/topiary.txt
@@ -4,9 +4,11 @@
 CONTENTS                                                      *topiary-contents*
 
     1. About ..................................|topiary-about|
-    2. Configuration ..........................|topiary-configuration|
-    3. Issues .................................|topiary-issues|
-    4. Licence ................................|topiary-licence|
+    2. Commands ...............................|topiary-commands|
+    3. Mappings ...............................|topiary-mappings|
+    4. Configuration ..........................|topiary-configuration|
+    5. Issues .................................|topiary-issues|
+    6. Licence ................................|topiary-licence|
 
 ==============================================================================
 ABOUT                                                            *topiary-about*
@@ -20,6 +22,41 @@ whitespace are removed:
 
 Additionally, multiple consecutive blank lines are collapsed to a single blank
 line.
+
+==============================================================================
+COMMANDS                                                      *topiary-commands*
+
+vim-topiary provides the following commands:
+
+                                                       *topiary-:TopiaryDisable*
+:TopiaryDisable         Disable whitespace trimming globally.
+
+                                                        *topiary-:TopiaryEnable*
+:TopiaryEnable          Enable whitespace trimming globally.
+
+                                                        *topiary-:TopiaryToggle*
+:TopiaryToggle          Toggle whitespace trimming globally.
+
+                                                 *topiary-:TopiaryDisableBuffer*
+:TopiaryDisableBuffer   Disable whitespace trimming for the current buffer.
+
+                                                  *topiary-:TopiaryEnableBuffer*
+:TopiaryEnableBuffer    Enable whitespace trimming for the current buffer.
+
+                                                  *topiary-:TopiaryToggleBuffer*
+:TopiaryToggleBuffer    Toggle whitespace trimming for the current buffer.
+
+==============================================================================
+MAPPINGS                                                      *topiary-mappings*
+
+vim-topiary provides the following |<Plug>| mappings:
+
+<Plug>TopiaryDisable        Execute :TopiaryDisable
+<Plug>TopiaryEnable         Execute :TopiaryEnable
+<Plug>TopiaryToggle         Execute :TopiaryToggle
+<Plug>TopiaryDisableBuffer  Execute :TopiaryDisableBuffer
+<Plug>TopiaryEnableBuffer   Execute :TopiaryEnableBuffer
+<Plug>TopiaryToggleBuffer   Execute :TopiaryToggleBuffer
 
 ==============================================================================
 CONFIGURATION                                            *topiary-configuration*

--- a/plugin/topiary.vim
+++ b/plugin/topiary.vim
@@ -7,6 +7,12 @@ if exists('g:loaded_topiary') || &compatible
 endif
 let g:loaded_topiary = 1
 
+if exists('g:topiary_enabled')
+    call topiary#CheckIsNumber(g:topiary_enabled, 'g:topiary_enabled')
+else
+    let g:topiary_enabled = 1
+endif
+
 if exists('g:topiary_ft_disabled')
     call topiary#CheckIsList(g:topiary_ft_disabled, 'g:topiary_ft_disabled')
 else
@@ -24,3 +30,11 @@ augroup topiary
     autocmd!
     autocmd BufWritePre * call topiary#TrimWhitespace()
 augroup END
+
+command -bar TopiaryDisable call topiary#Disable()
+command -bar TopiaryEnable call topiary#Enable()
+command -bar TopiaryToggle call topiary#Toggle()
+
+command -bar TopiaryDisableBuffer call topiary#DisableBuffer()
+command -bar TopiaryEnableBuffer call topiary#EnableBuffer()
+command -bar TopiaryToggleBuffer call topiary#ToggleBuffer()

--- a/plugin/topiary.vim
+++ b/plugin/topiary.vim
@@ -38,3 +38,11 @@ command -bar TopiaryToggle call topiary#Toggle()
 command -bar TopiaryDisableBuffer call topiary#DisableBuffer()
 command -bar TopiaryEnableBuffer call topiary#EnableBuffer()
 command -bar TopiaryToggleBuffer call topiary#ToggleBuffer()
+
+nnoremap <silent> <Plug>TopiaryDisable :TopiaryDisable<CR>
+nnoremap <silent> <Plug>TopiaryEnable :TopiaryEnable<CR>
+nnoremap <silent> <Plug>TopiaryToggle :TopiaryToggle<CR>
+
+nnoremap <silent> <Plug>TopiaryDisableBuffer :TopiaryDisableBuffer<CR>
+nnoremap <silent> <Plug>TopiaryEnableBuffer :TopiaryEnableBuffer<CR>
+nnoremap <silent> <Plug>TopiaryToggleBuffer :TopiaryToggleBuffer<CR>


### PR DESCRIPTION
This PR adds commands to toggle whitespace trimming both globally and for the current buffer:

* `:TopiaryEnable`: Enable whitespace trimming globally.
* `:TopiaryDisable`: Disable whitespace trimming globally.
* `:TopiaryToggle`: Toggle whitespace trimming globally.
* `:TopiaryEnableBuffer`: Enable whitespace trimming for the current buffer.
* `:TopiaryDisableBuffer`: Disable whitespace trimming for the current buffer.
* `:TopiaryToggleBuffer`: Toggle whitespace trimming for the current buffer.

For convenience of use, corresponding [`<Plug>`](https://neovim.io/doc/user/map.html#%3CPlug%3E) mappings are also added:

* `<Plug>TopiaryEnable`: Execute `:TopiaryEnable`.
* `<Plug>TopiaryDisable`: Execute `:TopiaryDisable`.
* `<Plug>TopiaryToggle`: Execute `:TopiaryToggle`.
* `<Plug>TopiaryEnableBuffer`: Execute `:TopiaryEnableBuffer`.
* `<Plug>TopiaryDisableBuffer`: Execute `:TopiaryDisableBuffer`.
* `<Plug>TopiaryToggleBuffer`: Execute `:TopiaryToggleBuffer`.

Closes #4.