### PR TITLE
Refactor type checking of user-set variables

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright © 2016-2018 Scott Stevenson <scott@stevenson.io>
+Copyright © 2016-2019 Scott Stevenson <scott@stevenson.io>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ let g:topiary_ft_allow_two_blank_lines = ['python']
 
 ## Copyright
 
-Copyright © 2016-2018 [Scott Stevenson].
+Copyright © 2016-2019 [Scott Stevenson].
 
 vim-topiary is distributed under the terms of the [ISC licence].
 

--- a/autoload/topiary.vim
+++ b/autoload/topiary.vim
@@ -59,34 +59,6 @@ function! s:CollapseMultipleBlankLines() abort
     endif
 endfunction
 
-function! topiary#CheckIsList(variable, name) abort
-    " Print an error message if variable is not of type List.
-    "
-    " Parameters
-    " ----------
-    " variable : Any
-    "     Value of the variable.
-    " name : String
-    "     Name of the variable.
-    if type(a:variable) != type([])
-        echoerr 'vim-topiary:' a:name 'must be a list'
-    endif
-endfunction
-
-function! topiary#CheckIsNumber(variable, name) abort
-    " Print an error message if variable is not of type Number.
-    "
-    " Parameters
-    " ----------
-    " variable : Any
-    "     Value of the variable.
-    " name : String
-    "     Name of the variable.
-    if type(a:variable) != type(0)
-        echoerr 'vim-topiary:' a:name 'must be a number'
-    endif
-endfunction
-
 function! topiary#TrimWhitespace() abort
     " Trim whitespace from the current buffer, if vim-topiary is enabled in
     " the buffer, or globally if there is no buffer local configuration, and

--- a/autoload/topiary.vim
+++ b/autoload/topiary.vim
@@ -15,7 +15,7 @@ function! s:InList(item, list) abort
     " Returns
     " -------
     " Number
-    "     1 if item is in list, 0 otherwise.
+    "     v:true if item is in list, v:false otherwise.
     return index(a:list, a:item) >= 0
 endfunction
 

--- a/plugin/topiary.vim
+++ b/plugin/topiary.vim
@@ -7,21 +7,56 @@ if exists('g:loaded_topiary') || &compatible
 endif
 let g:loaded_topiary = 1
 
+function! s:IsList(variable) abort
+    " Determine if a variable is a list.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if the variable is a list, v:false otherwise.
+    return type(a:variable) ==# type([])
+endfunction
+
+function! s:IsNumber(variable) abort
+    " Determine if a variable is a number.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if the variable is a number, v:false otherwise.
+    return type(a:variable) ==# type(0)
+endfunction
+
 if exists('g:topiary_enabled')
-    call topiary#CheckIsNumber(g:topiary_enabled, 'g:topiary_enabled')
+    if !s:IsNumber(g:topiary_enabled)
+        echoerr 'vim-topiary: g:topiary_enabled must be a number'
+    endif
 else
     let g:topiary_enabled = 1
 endif
 
 if exists('g:topiary_ft_disabled')
-    call topiary#CheckIsList(g:topiary_ft_disabled, 'g:topiary_ft_disabled')
+    if !s:IsList(g:topiary_ft_disabled)
+        echoerr 'vim-topiary: g:topiary_ft_disabled must be a list'
+    endif
 else
     let g:topiary_ft_disabled = ['diff']
 endif
 
 if exists('g:topiary_ft_allow_two_blank_lines')
-    call topiary#CheckIsList(g:topiary_ft_allow_two_blank_lines,
-                \ 'g:topiary_ft_allow_two_blank_lines')
+    if !s:IsList(g:topiary_ft_allow_two_blank_lines)
+        echoerr 'vim-topiary: g:topiary_ft_allow_two_blank_lines must be a list'
+    endif
 else
     let g:topiary_ft_allow_two_blank_lines = ['python']
 endif


### PR DESCRIPTION
Previously, the functions which checked that user-set configuration variables were of the correct type both checked the type of the variable, and printed an error message if the type was incorrect. In retrospect, this is a mixing of responsibilities. Now, the functions just check the type of the variable passed and return a boolean. At the call site the value of the boolean is used to determine whether an error message is printed.

Additionally, the functions were previously autoloaded. However, because they was called in `plugin/topiary.vim`, `autoload/topiary.vim` was sourced when Vim started, defeating the purpose of autoloading. Now the functions have been moved to `plugin/topiary.vim` instead of being autoloaded.
